### PR TITLE
set MSRV 1.62 in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tb6612fng"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.62"
 
 description = "A `no_std` driver for the TB6612FNG motor driver."
 repository = "https://github.com/rursprung/tb6612fng-rs"


### PR DESCRIPTION
this was forgotten in the previous MSRV bump.