### PR TITLE
CI: add security-events write permission

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  security-events: write # needed to upload SARIF reports on branch builds
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
this fixes the failure encountered when trying to upload the SARIF report during the CI run for the branch. in the PR it worked fine.

the fix was suggested here: https://github.com/github/codeql-action/issues/1720#issuecomment-1607963157