### PR TITLE
explicitly set outputs to documented state when calling `new()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 ### Changed
+* `Motor::new()` and `Driver::new()` methods now set the outputs upon their
+  initialisation to the documented defaults.
 * Update to `embedded-hal=1.0.0-rc.2`
 
 ## [0.2.0] - 2023-11-28


### PR DESCRIPTION
As discussed in #26